### PR TITLE
修复拼音首字母匹配bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,11 +63,10 @@ def search_teacher():
         # 模糊匹配
         partial_match = data[data['教师'].str.contains(regex, na=False) & (data['教师'] != teacher_name)]
         
-        # 拼音首字母匹配
         def match_pinyin_initials(name, initials):
             if pd.isna(name):
                 return False
-            teacher_names = name.split() # 假设教师名字之间用空格分隔
+            teacher_names = re.split(r'[；;，,\s、]+', name)
             for teacher in teacher_names:
                 if not teacher:
                     continue

--- a/app.py
+++ b/app.py
@@ -67,8 +67,14 @@ def search_teacher():
         def match_pinyin_initials(name, initials):
             if pd.isna(name):
                 return False
-            pinyin_initials = ''.join([p[0] for p in lazy_pinyin(name, style=Style.FIRST_LETTER)])
-            return pinyin_initials.startswith(initials.lower())
+            teacher_names = name.split() # 假设教师名字之间用空格分隔
+            for teacher in teacher_names:
+                if not teacher:
+                    continue
+                pinyin_initials = ''.join([p[0] for p in lazy_pinyin(teacher, style=Style.FIRST_LETTER)])
+                if pinyin_initials.startswith(initials.lower()):
+                    return True
+            return False
         
         pinyin_match = data[data['教师'].apply(lambda x: match_pinyin_initials(x, teacher_name))]
         


### PR DESCRIPTION
原首字母拼音搜索考虑的情况是只有一个老师，在有多位老师的情况下只会匹配第一个老师。现基于不同老师名称之间用空格隔开进行修复。